### PR TITLE
Added support for arm64 architectures

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var LIBC_TYPE = {
     unknown: 'unknown'
 };
 
-var bits = process.arch === 'x64' || process.arch === 'arm64' ? 64 : 32;
+var bits = ['x64', 'arm64', 'ppc64'].indexOf(process.arch) > -1 ? 64 : 32;
 
 function getLddOutput () {
     try {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var LIBC_TYPE = {
     unknown: 'unknown'
 };
 
-var bits = process.arch === 'x64' ? 64 : 32;
+var bits = process.arch === 'x64' || process.arch === 'arm64' ? 64 : 32;
 
 function getLddOutput () {
     try {


### PR DESCRIPTION
With MacBook M1, Linux virtual machines running under Parallels Desktop or VMWare Fusion usually run an arm64 architecture.  
Further described under the [process.arch documentation](https://nodejs.org/api/process.html#processarch).